### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.0
+
+### Added
+
+- Demo GIF showcasing CommandTree in action on README and website
+- Website demo section with window-chrome frame and caption below the hero
+- Deployment script fix for release workflow
+
+## 0.2.0
+
+### Added
+
+- See [Release 0.2.0](https://github.com/MelbourneDeveloper/CommandTree/releases/tag/v0.2.0)
+
 ## 0.1.0 - Initial Release
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commandtree",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commandtree",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "commandtree",
   "displayName": "CommandTree",
   "description": "Unified command runner: discover shell scripts, npm scripts, Makefiles, launch configs, VS Code tasks and more in one filterable tree",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Christian Findlay",
   "license": "MIT",
   "publisher": "nimblesite",


### PR DESCRIPTION
# TLDR;
Bump version to 0.3.0 and update changelog.

# Details
- Version bump in package.json and package-lock.json (0.2.0 → 0.3.0)
- CHANGELOG.md updated with 0.3.0 and backfilled 0.2.0 entry

# How do the tests prove the change works
Version bump and changelog only — no logic changes. Existing tests remain passing.