### PR TITLE
Make and Mise private task conventions in the tree view

### DIFF
--- a/src/CommandTreeProvider.ts
+++ b/src/CommandTreeProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { isPhonyTask, isPrivateTask } from "./models/TaskItem";
 import type { CommandItem, CategoryDef } from "./models/TaskItem";
 import type { CommandTreeItem } from "./models/TaskItem";
 import type { DiscoveryResult } from "./discovery";
@@ -6,7 +7,7 @@ import { discoverAllTasks, flattenTasks, getExcludePatterns, CATEGORY_DEFS } fro
 import { TagConfig } from "./config/TagConfig";
 import { logger } from "./utils/logger";
 import { buildNestedFolderItems } from "./tree/folderTree";
-import { createCommandNode, createCategoryNode } from "./tree/nodeFactory";
+import { createCategoryNode, createTaskNodes } from "./tree/nodeFactory";
 import { getAllRows } from "./db/db";
 import type { CommandRow } from "./db/db";
 import { getDbOrThrow } from "./db/lifecycle";
@@ -166,7 +167,7 @@ export class CommandTreeProvider implements vscode.TreeDataProvider<CommandTreeI
 
   private buildFlatCategory(def: CategoryDef, tasks: CommandItem[]): CommandTreeItem {
     const sorted = this.sortTasks(tasks);
-    const children = sorted.map((t) => createCommandNode(t));
+    const children = createTaskNodes(sorted);
     return createCategoryNode({
       label: `${def.label} (${tasks.length})`,
       children,
@@ -183,15 +184,44 @@ export class CommandTreeProvider implements vscode.TreeDataProvider<CommandTreeI
     return [...tasks].sort(comparator);
   }
 
+  private comparePrivateTasks(a: CommandItem, b: CommandItem): number {
+    return Number(isPrivateTask(a)) - Number(isPrivateTask(b));
+  }
+
+  private compareHelpTasks(a: CommandItem, b: CommandItem): number {
+    const isHelpA = a.type === "make" && a.label === "help";
+    const isHelpB = b.type === "make" && b.label === "help";
+    return Number(isHelpB) - Number(isHelpA);
+  }
+
+  private comparePhonyTasks(a: CommandItem, b: CommandItem): number {
+    return Number(isPhonyTask(b)) - Number(isPhonyTask(a));
+  }
+
+  private compareMakeTaskPriority(a: CommandItem, b: CommandItem): number {
+    if (a.type !== "make" || b.type !== "make") {
+      return 0;
+    }
+    return this.compareHelpTasks(a, b) || this.comparePhonyTasks(a, b);
+  }
+
   private getComparator(): (a: CommandItem, b: CommandItem) => number {
     const order = this.getSortOrder();
     if (order === "folder") {
-      return (a, b) => a.category.localeCompare(b.category) || a.label.localeCompare(b.label);
+      return (a, b) =>
+        a.category.localeCompare(b.category) ||
+        this.comparePrivateTasks(a, b) ||
+        this.compareMakeTaskPriority(a, b) ||
+        a.label.localeCompare(b.label);
     }
     if (order === "type") {
-      return (a, b) => a.type.localeCompare(b.type) || a.label.localeCompare(b.label);
+      return (a, b) =>
+        a.type.localeCompare(b.type) ||
+        this.comparePrivateTasks(a, b) ||
+        this.compareMakeTaskPriority(a, b) ||
+        a.label.localeCompare(b.label);
     }
-    return (a, b) => a.label.localeCompare(b.label);
+    return (a, b) => this.comparePrivateTasks(a, b) || this.compareMakeTaskPriority(a, b) || a.label.localeCompare(b.label);
   }
 
   private applyTagFilter(tasks: CommandItem[]): CommandItem[] {

--- a/src/discovery/make.ts
+++ b/src/discovery/make.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import type { CommandItem, IconDef, CategoryDef } from "../models/TaskItem";
+import type { CommandItem, MutableCommandItem, IconDef, CategoryDef } from "../models/TaskItem";
 import { generateCommandId, simplifyPath } from "../models/TaskItem";
 import { readFileContent } from "../utils/fileUtils";
 
@@ -28,6 +28,7 @@ export async function discoverMakeTargets(workspaceRoot: string, excludePatterns
 
   for (const file of allFiles) {
     const content = await readFileContent(file);
+    const phonyTargets = parsePhonyTargets(content);
     const targets = parseMakeTargets(content);
     const makeDir = path.dirname(file.fsPath);
     const category = simplifyPath(file.fsPath, workspaceRoot);
@@ -38,7 +39,7 @@ export async function discoverMakeTargets(workspaceRoot: string, excludePatterns
         continue;
       }
 
-      commands.push({
+      const command: MutableCommandItem = {
         id: generateCommandId("make", file.fsPath, name),
         label: name,
         type: "make",
@@ -48,7 +49,13 @@ export async function discoverMakeTargets(workspaceRoot: string, excludePatterns
         filePath: file.fsPath,
         tags: [],
         line,
-      });
+      };
+
+      if (phonyTargets.has(name)) {
+        command.isPhony = true;
+      }
+
+      commands.push(command);
     }
   }
 
@@ -58,6 +65,54 @@ export async function discoverMakeTargets(workspaceRoot: string, excludePatterns
 interface MakeTarget {
   readonly name: string;
   readonly line: number;
+}
+
+function addPhonyTargets(line: string, phonyTargets: Set<string>): void {
+  for (const name of line.split(/\s+/)) {
+    if (name !== "") {
+      phonyTargets.add(name);
+    }
+  }
+}
+
+function trimContinuation(line: string): string {
+  return line.endsWith("\\") ? line.slice(0, -1).trim() : line;
+}
+
+function isContinuationLine(line: string): boolean {
+  return line.endsWith("\\");
+}
+
+function readPhonyLine(line: string): string | undefined {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith(".PHONY:")) {
+    return undefined;
+  }
+  return trimmed.slice(".PHONY:".length).trim();
+}
+
+function parsePhonyTargets(content: string): ReadonlySet<string> {
+  const phonyTargets = new Set<string>();
+  let collecting = false;
+
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (collecting) {
+      addPhonyTargets(trimContinuation(trimmed), phonyTargets);
+      collecting = isContinuationLine(trimmed);
+      continue;
+    }
+
+    const phonyLine = readPhonyLine(line);
+    if (phonyLine === undefined) {
+      continue;
+    }
+
+    addPhonyTargets(trimContinuation(phonyLine), phonyTargets);
+    collecting = isContinuationLine(phonyLine);
+  }
+
+  return phonyTargets;
 }
 
 /**

--- a/src/models/TaskItem.ts
+++ b/src/models/TaskItem.ts
@@ -96,6 +96,7 @@ export interface CommandItem {
   readonly description?: string;
   readonly summary?: string;
   readonly securityWarning?: string;
+  readonly isPhony?: boolean;
   readonly line?: number;
 }
 
@@ -115,6 +116,7 @@ export interface MutableCommandItem {
   description?: string;
   summary?: string;
   securityWarning?: string;
+  isPhony?: boolean;
   line?: number;
 }
 
@@ -216,4 +218,16 @@ export function simplifyPath(filePath: string, workspaceRoot: string): string {
  */
 export function generateCommandId(type: CommandType, filePath: string, name: string): string {
   return `${type}:${filePath}:${name}`;
+}
+
+function supportsPrivateTaskStyling(type: CommandType): boolean {
+  return type === "make" || type === "mise";
+}
+
+export function isPrivateTask(task: CommandItem): boolean {
+  return supportsPrivateTaskStyling(task.type) && task.label.startsWith("_");
+}
+
+export function isPhonyTask(task: CommandItem): boolean {
+  return task.type === "make" && task.isPhony === true;
 }

--- a/src/test/e2e/treeview.e2e.test.ts
+++ b/src/test/e2e/treeview.e2e.test.ts
@@ -252,6 +252,7 @@ suite("TreeView E2E Tests", () => {
   suite("Private Make And Mise Tasks", () => {
     const makeRelativePath = "private-targets/Makefile";
     const miseRelativePath = "private-targets/mise.toml";
+    const privateDivider = "---------------- private ----------------";
     const publicLabels = ["alpha_public", "zeta_public"];
     const privateLabels = ["_beta_private", "_omega_private"];
 
@@ -267,6 +268,19 @@ suite("TreeView E2E Tests", () => {
         (item) =>
           isCommandItem(item.data) && item.data.type === type && item.data.filePath.endsWith(relativePath)
       );
+    }
+
+    async function getFolderChildrenForCategory(categoryLabel: string, folderLabel: string): Promise<CommandTreeItem[]> {
+      const provider = getCommandTreeProvider();
+      const categories = await provider.getChildren();
+      const category = categories.find((item) => getLabelString(item.label).includes(categoryLabel));
+      assert.ok(category !== undefined, `Should find category ${categoryLabel}`);
+
+      const children = await provider.getChildren(category);
+      const folder = children.find((item) => getLabelString(item.label) === folderLabel);
+      assert.ok(folder !== undefined, `Should find folder ${folderLabel}`);
+
+      return await provider.getChildren(folder);
     }
 
     setup(async function () {
@@ -321,6 +335,14 @@ suite("TreeView E2E Tests", () => {
 
       const items = await getItemsForFile("make", makeRelativePath);
       const labels = items.map((item) => getLabelString(item.label));
+      const folderChildren = await getFolderChildrenForCategory("Make Targets", "private-targets");
+      const folderLabels = folderChildren.map((item) => getLabelString(item.label));
+
+      assert.deepStrictEqual(
+        folderLabels,
+        [...publicLabels, privateDivider, ...privateLabels],
+        "Make targets should insert a divider between public and _-prefixed private targets"
+      );
 
       assert.deepStrictEqual(
         labels,
@@ -350,6 +372,14 @@ suite("TreeView E2E Tests", () => {
 
       const items = await getItemsForFile("mise", miseRelativePath);
       const labels = items.map((item) => getLabelString(item.label));
+      const folderChildren = await getFolderChildrenForCategory("Mise Tasks", "private-targets");
+      const folderLabels = folderChildren.map((item) => getLabelString(item.label));
+
+      assert.deepStrictEqual(
+        folderLabels,
+        [...publicLabels, privateDivider, ...privateLabels],
+        "Mise tasks should insert a divider between public and _-prefixed private tasks"
+      );
 
       assert.deepStrictEqual(
         labels,
@@ -372,6 +402,93 @@ suite("TreeView E2E Tests", () => {
           `Private mise task ${getLabelString(item.label)} should use a muted icon color`
         );
       }
+    });
+  });
+
+  suite("Make Target Conventions", () => {
+    const makeRelativePath = "make-conventions/Makefile";
+    const privateDivider = "---------------- private ----------------";
+
+    async function getFolderChildrenForCategory(categoryLabel: string, folderLabel: string): Promise<CommandTreeItem[]> {
+      const provider = getCommandTreeProvider();
+      const categories = await provider.getChildren();
+      const category = categories.find((item) => getLabelString(item.label).includes(categoryLabel));
+      assert.ok(category !== undefined, `Should find category ${categoryLabel}`);
+
+      const children = await provider.getChildren(category);
+      const folder = children.find((item) => getLabelString(item.label) === folderLabel);
+      assert.ok(folder !== undefined, `Should find folder ${folderLabel}`);
+
+      return await provider.getChildren(folder);
+    }
+
+    async function getMakeItemsForFile(relativePath: string): Promise<CommandTreeItem[]> {
+      const provider = getCommandTreeProvider();
+      const items = await collectLeafItems(provider);
+      return items.filter(
+        (item) => isCommandItem(item.data) && item.data.type === "make" && item.data.filePath.endsWith(relativePath)
+      );
+    }
+
+    setup(async function () {
+      this.timeout(15000);
+
+      writeFile(
+        makeRelativePath,
+        [
+          ".PHONY: help build _private",
+          "",
+          "aaa_file:",
+          '\t@echo "file target"',
+          "",
+          "help:",
+          '\t@echo "help target"',
+          "",
+          "build:",
+          '\t@echo "build target"',
+          "",
+          "%.o: %.c",
+          '\t@echo "pattern rule"',
+          "",
+          ".DEFAULT:",
+          '\t@echo "special target"',
+          "",
+          "_private:",
+          '\t@echo "private target"',
+        ].join("\n")
+      );
+
+      await refreshTasks();
+    });
+
+    teardown(async function () {
+      this.timeout(15000);
+      deleteFile(makeRelativePath);
+      await refreshTasks();
+    });
+
+    test("make help is pinned to the top, phony targets sort before non-phony ones, and special targets stay hidden", async function () {
+      this.timeout(15000);
+
+      const folderChildren = await getFolderChildrenForCategory("Make Targets", "make-conventions");
+      const folderLabels = folderChildren.map((item) => getLabelString(item.label));
+      const items = await getMakeItemsForFile(makeRelativePath);
+      const labels = items.map((item) => getLabelString(item.label));
+
+      assert.deepStrictEqual(
+        folderLabels,
+        ["help", "build", "aaa_file", privateDivider, "_private"],
+        "Make targets should pin help first, prefer phony public targets over non-phony ones, and separate private targets"
+      );
+
+      assert.deepStrictEqual(
+        labels,
+        ["help", "build", "aaa_file", "_private"],
+        "Only invokable make targets should remain after hiding special and pattern rules"
+      );
+
+      assert.ok(!labels.includes("%.o"), "Pattern rules should be hidden from Make discovery");
+      assert.ok(!labels.includes(".DEFAULT"), "Dot-prefixed special targets should be hidden from Make discovery");
     });
   });
 });

--- a/src/tree/folderTree.ts
+++ b/src/tree/folderTree.ts
@@ -2,7 +2,7 @@ import type { CommandItem } from "../models/TaskItem";
 import type { CommandTreeItem } from "../models/TaskItem";
 import type { DirNode } from "./dirTree";
 import { groupByFullDir, buildDirTree, needsFolderWrapper, getFolderLabel } from "./dirTree";
-import { createCommandNode, createFolderNode } from "./nodeFactory";
+import { createFolderNode, createTaskNodes } from "./nodeFactory";
 
 /**
  * Renders a DirNode as a folder CommandTreeItem.
@@ -20,7 +20,7 @@ function renderFolder({
 }): CommandTreeItem {
   const label = getFolderLabel(node.dir, parentDir);
   const folderId = `${parentTreeId}/${label}`;
-  const taskItems = sortTasks(node.tasks).map((t) => createCommandNode(t));
+  const taskItems = createTaskNodes(sortTasks(node.tasks));
   const subItems = node.subdirs.map((sub) =>
     renderFolder({
       node: sub,
@@ -66,7 +66,7 @@ export function buildNestedFolderItems({
           })
         );
       }
-      result.push(...sortTasks(node.tasks).map((t) => createCommandNode(t)));
+      result.push(...createTaskNodes(sortTasks(node.tasks)));
     } else if (needsFolderWrapper(node, rootNodes.length)) {
       result.push(
         renderFolder({
@@ -77,7 +77,7 @@ export function buildNestedFolderItems({
         })
       );
     } else {
-      result.push(...sortTasks(node.tasks).map((t) => createCommandNode(t)));
+      result.push(...createTaskNodes(sortTasks(node.tasks)));
     }
   }
 

--- a/src/tree/nodeFactory.ts
+++ b/src/tree/nodeFactory.ts
@@ -1,12 +1,22 @@
 import * as vscode from "vscode";
+import { isPrivateTask } from "../models/TaskItem";
 import type { CommandItem, CommandType, IconDef } from "../models/TaskItem";
 import { CommandTreeItem } from "../models/TaskItem";
 import { ICON_REGISTRY } from "../discovery";
 
 const DEFAULT_FOLDER_ICON = new vscode.ThemeIcon("folder");
+const PRIVATE_TASK_COLOR = new vscode.ThemeColor("descriptionForeground");
+const PRIVATE_TASK_DIVIDER = "---------------- private ----------------";
 
 function toThemeIcon(def: IconDef): vscode.ThemeIcon {
   return new vscode.ThemeIcon(def.icon, new vscode.ThemeColor(def.color));
+}
+
+function getTaskIcon(task: CommandItem): vscode.ThemeIcon {
+  if (isPrivateTask(task)) {
+    return new vscode.ThemeIcon(ICON_REGISTRY[task.type].icon, PRIVATE_TASK_COLOR);
+  }
+  return toThemeIcon(ICON_REGISTRY[task.type]);
 }
 
 function resolveContextValue(task: CommandItem): string {
@@ -48,8 +58,9 @@ function buildTooltip(task: CommandItem): vscode.MarkdownString {
 }
 
 function buildDescription(task: CommandItem): string {
+  const privateMarker = isPrivateTask(task) ? " private" : "";
   const tagStr = task.tags.length > 0 ? ` [${task.tags.join(", ")}]` : "";
-  return `${task.category}${tagStr}`;
+  return `${task.category}${privateMarker}${tagStr}`;
 }
 
 export function createCommandNode(task: CommandItem): CommandTreeItem {
@@ -62,7 +73,7 @@ export function createCommandNode(task: CommandItem): CommandTreeItem {
     id: task.id,
     contextValue: resolveContextValue(task),
     tooltip: buildTooltip(task),
-    iconPath: toThemeIcon(ICON_REGISTRY[task.type]),
+    iconPath: getTaskIcon(task),
     description: buildDescription(task),
     command: {
       command: "vscode.open",
@@ -73,6 +84,17 @@ export function createCommandNode(task: CommandItem): CommandTreeItem {
           : [vscode.Uri.file(task.filePath)],
     },
   });
+}
+
+export function createTaskNodes(tasks: CommandItem[]): CommandTreeItem[] {
+  const firstPrivateIndex = tasks.findIndex((task) => isPrivateTask(task));
+  if (firstPrivateIndex <= 0 || firstPrivateIndex === tasks.length) {
+    return tasks.map((task) => createCommandNode(task));
+  }
+
+  const publicNodes = tasks.slice(0, firstPrivateIndex).map((task) => createCommandNode(task));
+  const privateNodes = tasks.slice(firstPrivateIndex).map((task) => createCommandNode(task));
+  return [...publicNodes, createDividerNode(PRIVATE_TASK_DIVIDER), ...privateNodes];
 }
 
 export function createCategoryNode({
@@ -120,5 +142,15 @@ export function createPlaceholderNode(message: string): CommandTreeItem {
     children: [],
     id: message,
     contextValue: "placeholder",
+  });
+}
+
+export function createDividerNode(label: string): CommandTreeItem {
+  return new CommandTreeItem({
+    label,
+    data: { nodeType: "folder" },
+    children: [],
+    id: `divider:${label}`,
+    contextValue: "divider",
   });
 }


### PR DESCRIPTION
# TLDR;

It treats Make and Mise private tasks more like users expect. _-prefixed tasks are grouped below public tasks, separated by a divider, and visually de-emphasized. For Makefiles, help is prioritized to the top and .PHONY targets are preferred ahead of non-phony targets, while dot-prefixed special targets and % pattern rules remain hidden. Closes #13 

# Details

For Make and Mise:
- _-prefixed tasks are recognized as private/internal
- private tasks are sorted below public tasks
- a divider is inserted between public and private groups
- private tasks are rendered with a muted icon treatment and marked as private in the item description

For Make specifically:

- .PHONY declarations are parsed during discovery
- discovered Make targets now carry phony metadata
- help is pinned to the top of the Make group
- phony public targets sort ahead of non-phony public targets
- dot-prefixed special targets such as .PHONY and .DEFAULT remain hidden
- % pattern rules remain hidden
- The result is a tree that better reflects common GNU Make and Mise conventions, reduces accidental clicks on internal tasks, and makes the primary entry points easier to scan.

# How do the tests prove the change works

The E2E coverage in src/test/e2e/treeview.e2e.test.ts exercises the rendered tree, not just internal helpers.

The `Private Make And Mise Tasks` tests create temporary Make and Mise files and verify that:

- public tasks appear before private _ tasks
- a divider row appears between the groups
- private tasks are still present after the divider
- private tasks use the muted icon styling

The `Make Target Conventions` test verifies that:

- help is first
- phony public targets sort before non-phony public targets
- private targets appear below the divider
- % pattern rules are hidden
- dot-prefixed special targets are hidden
